### PR TITLE
adding mariadb-client install to integration tests of the Magento 2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -103,5 +103,8 @@ ADD conf/custom-xdebug.ini /usr/local/etc/php/conf.d/custom-xdebug.ini
 COPY ./bin/* /usr/local/bin/
 RUN chmod +x /usr/local/bin/*
 
+#Install Mariadb-client to phpunit tests
+RUN apt-get install -y mariadb-client-10.0
+
 VOLUME /var/www/html
 WORKDIR /var/www/html


### PR DESCRIPTION
I was trying run integration tests and i found it:
https://github.com/magento/magento2/issues/7044

I possibly solved the problema adding mariadb-client on docker container. I tested and it's working to me.

