### PR TITLE
Adding Elasticsearch in order to let this resource available to use in case necessary

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,15 @@ Enjoy your new panels!
 | `./xdebug`  |  Enable / Disable the XDebug | |
 | `./composer`  |  Use Composer commands | `./composer update` |
 
+### Elasticsearch 
+
+To use elastic search you can use this command below:
+`$ docker-compose -f docker-compose.yml -f docker-compose.elasticsearch.yml up`
+or to run in the background using detached mode
+`$docker-compose -f docker-compose.yml -f docker-compose.elasticsearch.yml up -d`
+
+**Elasticsearch:** http://localhost:9200
+
 ### License
 
 MIT © 2018 [Rafael Corrêa Gomes](https://github.com/rafaelstz/) and [contributors](https://github.com/clean-docker/Magento2/graphs/contributors).

--- a/docker-compose.elasticsearch.yml
+++ b/docker-compose.elasticsearch.yml
@@ -1,0 +1,18 @@
+version: '2'
+services:
+  elasticsearch:
+    image: elasticsearch:2.4
+    environment:
+      - cluster.name=docker-cluster
+      - bootstrap.memory_lock=true
+      - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
+    ulimits:
+      memlock:
+        soft: -1
+        hard: -1
+    volumes:
+      - ./elasticsearchdata:/usr/share/elasticsearch/data
+    ports:
+      - 9200:9200
+    networks:
+      - <project_name>-network

--- a/elasticsearchdata/.gitignore
+++ b/elasticsearchdata/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore


### PR DESCRIPTION
Elasticsearch is running in default port 9200 and is the last version supported by Magento 2. 

I have tested in the last version stable of the Magento : 2.2