### PR TITLE
Adjusting code standard and wrong break line on READ.md

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -77,8 +77,8 @@ RUN composer global require hirak/prestissimo
 # Install Code Sniffer
 
 RUN composer global require "squizlabs/php_codesniffer=*"
-RUN composer global require magento-ecg/coding-standard
-RUN ~/.composer/vendor/bin/phpcs --config-set installed_paths ~/.composer/vendor/magento-ecg/coding-standard
+RUN git clone https://github.com/magento/marketplace-eqp.git ~/.composer/vendor/magento/marketplace-eqp
+RUN ~/.composer/vendor/bin/phpcs --config-set installed_paths ~/.composer/vendor/magento/marketplace-eqp
 RUN ln -s ~/.composer/vendor/bin/phpcs /usr/local/bin;
 ENV PATH="/var/www/.composer/vendor/bin/:${PATH}"
 

--- a/README.md
+++ b/README.md
@@ -73,9 +73,12 @@ Enjoy your new panels!
 ### Elasticsearch 
 
 To use elastic search you can use this command below:
+
 `$ docker-compose -f docker-compose.yml -f docker-compose.elasticsearch.yml up`
+
 or to run in the background using detached mode
-`$docker-compose -f docker-compose.yml -f docker-compose.elasticsearch.yml up -d`
+
+`$ docker-compose -f docker-compose.yml -f docker-compose.elasticsearch.yml up -d`
 
 **Elasticsearch:** http://localhost:9200
 


### PR DESCRIPTION
1) Code standard was using a non-official code standard. Replace to official code standard repository below:
https://github.com/magento/marketplace-eqp

> It is being installed using `git` avoid the credential use to Magento marketplace.

2) Adjusting break line missing of the READ.md on elastic search section.
