### PR TITLE
Not needed on Windows

### DIFF
--- a/start
+++ b/start
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
-sudo ifconfig lo0 alias 10.254.254.254
 docker-sync start && \
 docker-compose up -d && \
 version=$(git describe --tags $(git rev-list --tags --max-count=1))


### PR DESCRIPTION
Will throw an error when executed in WSL on Windows. 

Note: WSL is required for Docker Sync to work on Windows.