### PR TITLE
Uptate to PHP 7.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7.1-apache
+FROM php:7.4-apache
 
 MAINTAINER Rafael Corrêa Gomes <rafaelcgstz@gmail.com>
 


### PR DESCRIPTION
- magento/product-community-edition 2.4.3 requires php ~7.3.0||~7.4.0 -> your PHP version (7.1.29) does not satisfy that requirement.